### PR TITLE
Added section on the security of in-browser communication flows

### DIFF
--- a/draft-ietf-oauth-browser-based-apps.md
+++ b/draft-ietf-oauth-browser-based-apps.md
@@ -1399,7 +1399,7 @@ In browser-based apps, it is common to execute the OAuth flow in a secondary win
 In these flows, the browser-based app holds control of the primary window, for instance, to avoid page refreshes or run silent frame-based flows.
 
 If the browser-based app and the authorization server are invoked in different frames, they have to use in-browser communication techniques like the postMessage API (a.k.a. {{WebMessaging}}) instead of top-level redirections.
-To guarantee confidentiality and authenticity of messages, both the initiator origin and receiver origin of a postMessage have to be verified using the mechanisms inherently provided by the postMessage API (Section 9.3.2 in {{WebMessaging}}).
+To guarantee confidentiality and authenticity of messages, both the initiator origin and receiver origin of a postMessage MUST be verified using the mechanisms inherently provided by the postMessage API (Section 9.3.2 in {{WebMessaging}}).
 
 Section 4.18. of {{oauth-security-topics}} provides additional details about the security of in-browser communication flows and the countermeasures that browser-based apps and authorization servers MUST apply to defend against these attacks.
 

--- a/draft-ietf-oauth-browser-based-apps.md
+++ b/draft-ietf-oauth-browser-based-apps.md
@@ -143,6 +143,13 @@ informative:
       org: Google, Inc
     date: October 2018
     target: https://www.w3.org/TR/CSP3/
+  WebMessaging:
+    title: HTML Living Standard - Cross-document messaging
+    author:
+      name: whatwg
+      ins: whatwg
+    date: December 2023
+    target: https://html.spec.whatwg.org/multipage/web-messaging.html#web-messaging
 
 --- abstract
 
@@ -1381,6 +1388,20 @@ only be used if identifying the issuer as described is not possible.
 
 Section 4.4 of {{oauth-security-topics}} provides additional details about mix-up attacks
 and the countermeasures mentioned above.
+
+
+
+
+Security of In-Browser Communication Flows {#in_browser_communication_security}
+--------------------------------------
+
+In browser-based apps, it is common to execute the OAuth flow in a secondary window, such as a popup or iframe, instead of redirecting the primary window.
+In these flows, the browser-based app holds control of the primary window, for instance, to avoid page refreshes or run silent frame-based flows.
+
+If the browser-based app and the authorization server are invoked in different frames, they have to use in-browser communication techniques like the postMessage API (a.k.a. {{WebMessaging}}) instead of top-level redirections.
+To guarantee confidentiality and authenticity of messages, both the initiator origin and receiver origin of a postMessage have to be verified using the mechanisms inherently provided by the postMessage API (Section 9.3.2 in {{WebMessaging}}).
+
+Section 4.18. of {{oauth-security-topics}} provides additional details about the security of in-browser communication flows and the countermeasures that browser-based apps and authorization servers MUST apply to defend against these attacks.
 
 
 


### PR DESCRIPTION
As discussed on the OSW, this PR adds a small section with security considerations on the use of `postMessage` (a.k.a. "web messaging") to this draft. It makes reference to [Section 4.18 of the OAuth BCP](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics-24#name-attacks-on-in-browser-commu), which already discusses the security implications of in-browser communication flows in detail.

Since (silent) iframe flows and popup flows are especially used in browser-based apps, we think that it makes sense to include security considerations of their in-browser communication into this draft. Please let us know what you think about this. We appreciate any feedback.